### PR TITLE
✨ feat: menucomment response query 작성

### DIFF
--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/dto/request/CafeInfoRequest.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/dto/request/CafeInfoRequest.java
@@ -4,9 +4,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mainproject.cafeIn.domain.cafe.entity.Cafe;
+import mainproject.cafeIn.domain.owner.entity.Owner;
 
 import javax.validation.constraints.NotNull;
-import java.security.acl.Owner;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/dto/response/GetCafesResponse.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/dto/response/GetCafesResponse.java
@@ -1,6 +1,9 @@
 package mainproject.cafeIn.domain.cafe.dto.response;
 
 import lombok.Getter;
+import mainproject.cafeIn.domain.tag.entity.Tag;
+
+import java.util.List;
 
 @Getter
 public class GetCafesResponse {

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/entity/Cafe.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/entity/Cafe.java
@@ -1,24 +1,25 @@
 package mainproject.cafeIn.domain.cafe.entity;
 
-import lombok.*;
-import mainproject.cafeIn.domain.cafe.dto.request.CafeInfoRequest;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import mainproject.cafeIn.domain.menu.entity.Menu;
+import mainproject.cafeIn.domain.owner.entity.Owner;
 import mainproject.cafeIn.global.base.BaseEntity;
 import mainproject.cafeIn.global.exception.CustomException;
 import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
-import java.security.acl.Owner;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static javax.persistence.CascadeType.*;
-import static javax.persistence.FetchType.*;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.FetchType.LAZY;
 import static mainproject.cafeIn.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
-import static org.hibernate.annotations.OnDeleteAction.*;
+import static org.hibernate.annotations.OnDeleteAction.CASCADE;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/member/service/MemberService.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/member/service/MemberService.java
@@ -143,7 +143,7 @@ public class MemberService {
         }
     }
 
-    private Member findById(long id) {
+    public Member findById(long id) {
 
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menu/dto/response/GetMenuDetailResponse.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menu/dto/response/GetMenuDetailResponse.java
@@ -1,13 +1,16 @@
 package mainproject.cafeIn.domain.menu.dto.response;
 
 import lombok.Getter;
+import mainproject.cafeIn.domain.menucomment.dto.response.MenuCommentResponse;
+
+import java.util.List;
 
 @Getter
 public class GetMenuDetailResponse {
     private MenuResponse menu;
-    private List<MenuCommentsResponse> comments;
+    private List<MenuCommentResponse> comments;
 
-    public GetMenuDetailResponse(MenuResponse menu, List<MenuCommentsResponse> comments) {
+    public GetMenuDetailResponse(MenuResponse menu, List<MenuCommentResponse> comments) {
         this.menu = menu;
         this.comments = comments;
     }

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menucomment/repository/MenuCommentRepositoryCustom.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menucomment/repository/MenuCommentRepositoryCustom.java
@@ -1,4 +1,9 @@
 package mainproject.cafeIn.domain.menucomment.repository;
 
+import mainproject.cafeIn.domain.menucomment.dto.response.MenuCommentResponse;
+
+import java.util.List;
+
 public interface MenuCommentRepositoryCustom {
+    List<MenuCommentResponse> getMenuComments(Long menuId);
 }

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menucomment/repository/implementation/MenuCommentRepositoryImpl.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menucomment/repository/implementation/MenuCommentRepositoryImpl.java
@@ -1,6 +1,31 @@
 package mainproject.cafeIn.domain.menucomment.repository.implementation;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mainproject.cafeIn.domain.menucomment.dto.response.MenuCommentResponse;
+import mainproject.cafeIn.domain.menucomment.dto.response.QMenuCommentResponse;
 import mainproject.cafeIn.domain.menucomment.repository.MenuCommentRepositoryCustom;
 
+import java.util.List;
+
+import static mainproject.cafeIn.domain.member.entity.QMember.member;
+import static mainproject.cafeIn.domain.menucomment.entity.QMenuComment.menuComment;
+
+@RequiredArgsConstructor
 public class MenuCommentRepositoryImpl implements MenuCommentRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MenuCommentResponse> getMenuComments(Long menuId) {
+        return queryFactory
+                .select(new QMenuCommentResponse(
+                        menuComment.content,
+                        member.id,
+                        member.displayName
+                ))
+                .from(menuComment)
+                .innerJoin(menuComment.member, member).fetchJoin()
+                .where(menuComment.menu.id.eq(menuId))
+                .fetch();
+    }
 }

--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menucomment/service/MenuCommentService.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/menucomment/service/MenuCommentService.java
@@ -2,15 +2,18 @@ package mainproject.cafeIn.domain.menucomment.service;
 
 import lombok.RequiredArgsConstructor;
 import mainproject.cafeIn.domain.member.entity.Member;
+import mainproject.cafeIn.domain.member.service.MemberService;
 import mainproject.cafeIn.domain.menu.entity.Menu;
 import mainproject.cafeIn.domain.menu.service.MenuService;
 import mainproject.cafeIn.domain.menucomment.dto.request.MenuCommentRequest;
+import mainproject.cafeIn.domain.menucomment.dto.response.MenuCommentResponse;
 import mainproject.cafeIn.domain.menucomment.entity.MenuComment;
 import mainproject.cafeIn.domain.menucomment.repository.MenuCommentRepository;
 import mainproject.cafeIn.global.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static mainproject.cafeIn.global.exception.ErrorCode.COMMENT_NOT_FOUND;
@@ -26,7 +29,7 @@ public class MenuCommentService {
 
     @Transactional
     public void createMenuComment(Long loginId, Long menuId, MenuCommentRequest request) {
-        Member member = memberService.findMemberById(loginId);
+        Member member = memberService.findById(loginId);
         Menu menu = menuService.findMenuById(menuId);
         Optional<Long> commentId = findMenuCommentByMemberIdAndMenuId(loginId, menuId);
         if (commentId.isPresent()) {
@@ -38,7 +41,7 @@ public class MenuCommentService {
 
     @Transactional
     public Long updateMenuComment(Long loginId, Long commentId, MenuCommentRequest request) {
-        Member member = memberService.findMemberById(loginId);
+        Member member = memberService.findById(loginId);
         MenuComment menuComment = findMenuCommentById(commentId);
         menuComment.update(request.getContent());
 
@@ -47,7 +50,7 @@ public class MenuCommentService {
 
     @Transactional
     public Long deleteMenuComment(Long loginId, Long commentId) {
-        Member member = memberService.findMemberById(loginId);
+        Member member = memberService.findById(loginId);
         MenuComment menuComment = findMenuCommentById(commentId);
         Long menuId = menuComment.getMenu().getId();
         menuCommentRepository.delete(menuComment);
@@ -64,5 +67,10 @@ public class MenuCommentService {
     private Optional<Long> findMenuCommentByMemberIdAndMenuId(Long memberId, Long menuId) {
 
         return menuCommentRepository.findMenuCommentByMemberIdAndMenuId(memberId, menuId);
+    }
+
+    public List<MenuCommentResponse> getMenuComments(Long menuId) {
+
+        return menuCommentRepository.getMenuComments(menuId);
     }
 }


### PR DESCRIPTION
### 🖐🏻 카테고리

---

- [X] Feature
- [ ] Refactor
- [ ] Fix
- [ ] Test

### 🔥 핵심 구현사항

---

- 메뉴 상세 조회 시 필요한 댓글 response를 queryDsl을 사용해 구현했습니다.
