### PR TITLE
🐛 fix: extractAreaFromAddress 메서드 로직 정규식->split 수정 (2023.07.12 조하얀)

### DIFF
--- a/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/entity/Cafe.java
+++ b/server/cafeIn/src/main/java/mainproject/cafeIn/domain/cafe/entity/Cafe.java
@@ -124,14 +124,14 @@ public class Cafe extends BaseEntity {
     }
 
     private String extractAreaFromAddress(String address) {
-        String pattern = "\\b(\\w+구)\\b";
-        Pattern regex = Pattern.compile(pattern);
-        Matcher matcher = regex.matcher(address);
+        // TODO: 주소 추출 로직 수정
+        String[] splitAddress = address.split(" ");
 
-        // TODO: ErrorCode 수정
-        if (matcher.find()) {
-            return matcher.group(1);
-        } else throw new CustomException(INTERNAL_SERVER_ERROR);
+        if (splitAddress.length < 1) {
+            throw new CustomException(INTERNAL_SERVER_ERROR);
+        } else {
+            return splitAddress[1];
+        }
     }
 
     public void validateOwner(Long ownerId) {


### PR DESCRIPTION
### 🖐🏻 카테고리

---

- [ ] Feature
- [ ] Refactor
- [X] Fix
- [ ] Test

### 🔥 핵심 구현사항

---

- extractAreaFromAddress 메서드 수정
정규식을 사용해 구로 끝나는 부분을 반환하도록 했지만 제대로 작동하지 않아서 임시로 split을 사용해 배열의 1번 인덱스 값을 반환하도록 했습니다.
이것도 확실한 추출 로직이라고 하기 어려워 더 고민해봐야 할 것 같습니다.
