### PR TITLE
카페 메뉴 삭제 구현 / 지도에 카페 인포윈도우 띄우기 구현 

### DIFF
--- a/client/src/components/cafe/CafeInfo.tsx
+++ b/client/src/components/cafe/CafeInfo.tsx
@@ -35,7 +35,7 @@ const CafeInfo = () => {
     isPetFriendly: false,
     hasDessert: false,
   });
-  const [imageFile, setImageFile] = useState<string | Blob>("");
+  const [imageFile, setImageFile] = useState<string | Blob | null>(null);
   const [previewImage, setPreviewImage] = useState<string | null>("");
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -123,6 +123,8 @@ const CafeInfo = () => {
     const formData = new FormData();
     if (imageFile) {
       formData.append("cafeImage", imageFile);
+    } else {
+      formData.append("cafeImage", null);
     }
     const json = JSON.stringify(CafeData);
     const info = new Blob([json], { type: "application/json" });

--- a/client/src/components/cafe/DeleteCafe.tsx
+++ b/client/src/components/cafe/DeleteCafe.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import axios from "axios";
+import { styled } from "styled-components";
+import { COLOR_1 } from "../../common/common";
+import { Modal } from "react-responsive-modal";
+import { baseURL } from "../../common/baseURL";
+import Button from "../../common/button/button";
+const DeleteCafe = ({ cafeId }: { cafeId: string | undefined }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [password, setPassword] = useState("");
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleDeleteCafe = () => {
+    // axios를 사용하여 삭제 요청 보내기
+    axios
+      .delete(`${baseURL}/cafes/${cafeId}`, {
+        data: { password },
+        headers: {
+          Authorization: localStorage.getItem("access_token"),
+        },
+      })
+      .then((response) => {
+        console.log("카페 삭제 요청 성공:", response.data);
+      })
+      .catch((error) => {
+        console.error("카페 삭제 요청 실패:", error);
+
+        // 삭제 요청이 실패했을 때 비밀번호가 틀렸다 안내
+      });
+
+    // 모달 닫기
+    handleCloseModal();
+  };
+
+  return (
+    <>
+      <CafeDeleteBtn onClick={handleOpenModal}>내 카페 삭제하기</CafeDeleteBtn>
+      <Modal
+        open={isModalOpen}
+        onClose={handleCloseModal}
+        center
+        styles={modalStyles}
+      >
+        <ModalDiv>
+          <ModalHeader>카페를 삭제하시겠습니까?</ModalHeader>
+          <ModalContent>카페 삭제를 위해 비밀번호를 입력해주세요</ModalContent>
+          <PasswordInput
+            type='password'
+            value={password}
+            onChange={handlePasswordChange}
+          />
+        </ModalDiv>
+        <ButtonDiv>
+          <Button
+            type='button'
+            text='삭제'
+            theme='Confirm'
+            onClick={handleDeleteCafe}
+          />
+          <Button
+            type='button'
+            text='취소'
+            theme='Cancel'
+            onClick={handleCloseModal}
+          />
+        </ButtonDiv>
+      </Modal>
+    </>
+  );
+};
+
+const modalStyles = {
+  modal: {
+    // 모달 전체 스타일
+    // 예시:
+    width: "420px",
+    height: "210px",
+    borderRadius: "20px",
+    padding: "20px",
+  },
+};
+const ModalDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+const ModalHeader = styled.div`
+  width: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${COLOR_1.dark_brown};
+  font-size: 20px;
+  font-weight: bold;
+  padding: 2px;
+  border-bottom: 4px solid ${COLOR_1.dark_sand};
+`;
+const ModalContent = styled.div`
+  padding: 20px;
+  text-align: center;
+`;
+const PasswordInput = styled.input`
+  width: 200px;
+  padding: 8px;
+  margin-bottom: 20px;
+`;
+
+const ButtonDiv = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const CafeDeleteBtn = styled.button`
+  width: 105px;
+  height: 32px;
+  border-radius: 20px;
+  background-color: ${COLOR_1.light_red};
+  color: white;
+  border: none;
+  margin-left: 10px;
+  font-family: "TheJamsil5Bold";
+  box-shadow: 1px 2px 4px #7c6881;
+  & :hover {
+    cursor: pointer;
+  }
+`;
+export default DeleteCafe;

--- a/client/src/components/cafe/EditCafeInfo.tsx
+++ b/client/src/components/cafe/EditCafeInfo.tsx
@@ -91,6 +91,7 @@ const EditCafeInfo = ({ cafeId }: { cafeId: string | undefined }) => {
         setEditData((prevEditData) => ({
           ...prevEditData,
           address: coordinates.address_name,
+          shortAddress: coordinates.region_2depth_name,
           latitude: coordinates.y,
           longitude: coordinates.x,
         }));

--- a/client/src/components/cafe/EditCafeInfo.tsx
+++ b/client/src/components/cafe/EditCafeInfo.tsx
@@ -38,7 +38,7 @@ const EditCafeInfo = ({ cafeId }: { cafeId: string | undefined }) => {
     isPetFriendly: false,
     hasDessert: false,
   });
-  const [imageFile, setImageFile] = useState<null | string | Blob>("");
+  const [imageFile, setImageFile] = useState<null | string | Blob>(null);
   const [previewImage, setPreviewImage] = useState<string | null>("");
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -155,6 +155,8 @@ const EditCafeInfo = ({ cafeId }: { cafeId: string | undefined }) => {
     // if (imageFile) {
     if (imageFile) {
       formData.append("cafeImage", imageFile); //이미지 수정 안했을 때 이미지 그대로 다시 해야되는거 수정
+    } else {
+      formData.append("cafeImage", null);
     }
     const json = JSON.stringify(editData);
     const info = new Blob([json], { type: "application/json" });

--- a/client/src/components/cafe/EditCafeInfo.tsx
+++ b/client/src/components/cafe/EditCafeInfo.tsx
@@ -38,7 +38,7 @@ const EditCafeInfo = ({ cafeId }: { cafeId: string | undefined }) => {
     isPetFriendly: false,
     hasDessert: false,
   });
-  const [imageFile, setImageFile] = useState<string | Blob>("");
+  const [imageFile, setImageFile] = useState<null | string | Blob>("");
   const [previewImage, setPreviewImage] = useState<string | null>("");
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -153,8 +153,9 @@ const EditCafeInfo = ({ cafeId }: { cafeId: string | undefined }) => {
 
     const formData = new FormData();
     // if (imageFile) {
-    formData.append("cafeImage", imageFile); //이미지 수정 안했을 때 이미지 그대로 다시 해야되는거 수정
-    // }
+    if (imageFile) {
+      formData.append("cafeImage", imageFile); //이미지 수정 안했을 때 이미지 그대로 다시 해야되는거 수정
+    }
     const json = JSON.stringify(editData);
     const info = new Blob([json], { type: "application/json" });
     formData.append("dto", info);

--- a/client/src/components/main/Map.tsx
+++ b/client/src/components/main/Map.tsx
@@ -2,11 +2,61 @@ import { COLOR_1 } from "../../common/common";
 import styled from "styled-components";
 import { FONT_SIZE_1 } from "../../common/common";
 import { useEffect } from "react";
+
 declare global {
   interface Window {
     kakao: any;
   }
 }
+const mockData = {
+  message: "성공적으로 요청을 불러왔습니다.",
+  payload: {
+    content: [
+      {
+        cafeId: 1,
+        name: "카페1",
+        address: "서울특별시 강서구 마곡중앙6로 45",
+        rating: 0,
+        latitude: 37.546987418,
+        longitude: 126.874844438,
+        image:
+          "https://be-cafein.s3.ap-northeast-2.amazonaws.com/cafes/5f365ca7-804e-4016-be01-260fd34d465f_%25E1%2584%2583%25E1%2585%25A1%25E1%2584%258B%25E1%2585%25AE%25E1%2586%25AB%25E1%2584%2585%25E1%2585%25A9%25E1%2584%2583%25E1%2585%25B3_%25282%2529.png",
+        countBookmark: 0,
+        countPost: 0,
+        bookmarked: false,
+        isBookmarked: false,
+      },
+      {
+        cafeId: 2,
+        name: "카페2",
+        address: "서울특별시 강서구 마곡중앙6로 45",
+        rating: 0,
+        latitude: 37.549328709,
+        longitude: 126.913624675,
+        image:
+          "https://be-cafein.s3.ap-northeast-2.amazonaws.com/cafes/5f365ca7-804e-4016-be01-260fd34d465f_%25E1%2584%2583%25E1%2585%25A1%25E1%2584%258B%25E1%2585%25AE%25E1%2586%25AB%25E1%2584%2585%25E1%2585%25A9%25E1%2584%2583%25E1%2585%25B3_%25282%2529.png",
+        countBookmark: 0,
+        countPost: 0,
+        bookmarked: false,
+        isBookmarked: false,
+      },
+      {
+        cafeId: 3,
+        name: "카페우드진",
+        address: "서울특별시 강서구 마곡중앙6로 45",
+        rating: 0,
+        latitude: 37.556034031,
+        longitude: 126.91013117,
+        image:
+          "https://be-cafein.s3.ap-northeast-2.amazonaws.com/cafes/5f365ca7-804e-4016-be01-260fd34d465f_%25E1%2584%2583%25E1%2585%25A1%25E1%2584%258B%25E1%2585%25AE%25E1%2586%25AB%25E1%2584%2585%25E1%2585%25A9%25E1%2584%2583%25E1%2585%25B3_%25282%2529.png",
+        countBookmark: 0,
+        countPost: 0,
+        bookmarked: false,
+        isBookmarked: false,
+      },
+    ],
+  },
+};
 const S = {
   Container: styled.div`
     display: flex;
@@ -46,19 +96,48 @@ const S = {
   `,
 };
 
-const { kakao } = window;
+const createMarkerAndInfowindow = (map: any, cafe: any) => {
+  const markerPosition = new kakao.maps.LatLng(cafe.latitude, cafe.longitude);
+  console.log(cafe.latitude);
+  const marker = new kakao.maps.Marker({
+    position: markerPosition,
+  });
+  marker.setMap(map);
+
+  const iwContent = `<div style="padding:5px; border:1px solid green; ">
+  ${cafe.name} 
+  <div style="font-size:5px">${cafe.address}</div>
+  <a href="https://cafein34.vercel.app/cafes/${cafe.cafeId}" style="color:green; font-size:10px;" target="_blank">카페 보러가기</a>
+  </div> `;
+  const iwPosition = new kakao.maps.LatLng(cafe.latitude, cafe.longitude);
+  const iwRemoveable = true;
+  const infowindow = new kakao.maps.InfoWindow({
+    position: iwPosition,
+    content: iwContent,
+    removable: iwRemoveable,
+  });
+
+  kakao.maps.event.addListener(marker, "click", function () {
+    infowindow.open(map, marker);
+  });
+};
+
 const Map = () => {
   useEffect(() => {
     const container = document.getElementById("map");
     if (container !== null) {
       const options = {
-        center: new kakao.maps.LatLng(33.450701, 126.570667),
-        level: 3,
+        center: new kakao.maps.LatLng(37.549328709, 126.913624675), //합정역
+        level: 8,
       };
       const map = new kakao.maps.Map(container, options);
-      console.log(map);
+
+      mockData.payload.content.forEach((cafe: any) => {
+        createMarkerAndInfowindow(map, cafe);
+      });
     }
   }, []);
+
   return <S.Container id='map'></S.Container>;
 };
 export default Map;

--- a/client/src/components/modal/CafeFollowerModal.tsx
+++ b/client/src/components/modal/CafeFollowerModal.tsx
@@ -56,34 +56,7 @@ interface Follower {
   image?: string;
 }
 const CafeFollowerModal = () => {
-  const mockData = [
-    {
-      id: 1,
-      displayName: "커피나라1",
-      image: undefined,
-    },
-    {
-      id: 2,
-      displayName: "커피2",
-      image: undefined,
-    },
-    {
-      id: 2,
-      displayName: "커피3",
-      image: undefined,
-    },
-    {
-      id: 4,
-      displayName: "커피4",
-      image: undefined,
-    },
-    {
-      id: 5,
-      displayName: "커피6",
-      image: undefined,
-    },
-  ];
-  const [dataSource, setDataSource] = useState<Follower[]>(mockData);
+  const [dataSource, setDataSource] = useState<Follower[]>();
   const [hasMore, setHasMore] = useState(true);
   const fetchMoreData = () => {
     if (dataSource.length < 100) {

--- a/client/src/components/otheruser/OtherUserPageBox.tsx
+++ b/client/src/components/otheruser/OtherUserPageBox.tsx
@@ -286,7 +286,7 @@ const OtherUserMyPageBox = () => {
     {
       id: 1,
       cafeName: "동대문 카페",
-      image: undefined,
+      image: "",
       address: "서울시 동대문구",
       rating: 1,
       title: "먹자",

--- a/client/src/components/owners/OwnerMyPageBox.tsx
+++ b/client/src/components/owners/OwnerMyPageBox.tsx
@@ -7,7 +7,7 @@ import CafeFollowerModal from "../modal/CafeFollowerModal";
 import styled from "styled-components";
 import { Link, useNavigate } from "react-router-dom";
 import { baseURL } from "../../common/baseURL";
-
+import DeleteCafe from "../cafe/DeleteCafe";
 const S = {
   Container: styled.div`
     width: 90vw;
@@ -24,7 +24,7 @@ const S = {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: 400px;
+    height: 300px;
     width: 90vw;
     @media screen and (min-width: 500px) {
       width: 480px;
@@ -50,6 +50,7 @@ const S = {
   EditButtonBox: styled.div`
     display: flex;
     justify-content: right;
+    align-items: center;
     height: 60px;
     width: 90vw;
     @media screen and (min-width: 500px) {
@@ -71,7 +72,8 @@ const S = {
     border-radius: 20px;
     color: ${COLOR_1.dark_sand};
     background-color: ${COLOR_1.ivory};
-    border: solid 1px ${COLOR_1.dark_brown};
+    /* border: solid 1px ${COLOR_1.dark_brown}; */
+    box-shadow: 1px 1px 2px #a57d52;
     cursor: pointer;
     &:hover {
       background-color: #a57d52;
@@ -185,25 +187,29 @@ const S = {
     }
   `,
   SandButton: styled.button`
-    height: 5vh;
+    height: 50px;
     width: 290px;
     border-radius: 15px;
     border: none;
     margin-top: 10px;
+    margin-bottom: 4px;
     background-color: ${COLOR_1.ivory};
     color: ${COLOR_1.dark_brown};
+    font-family: "TheJamsil5Bold";
     font-size: ${FONT_SIZE_1.normal_2};
-    font-weight: bold;
-    border: solid 1px ${COLOR_1.dark_brown};
+    box-shadow: 2px 2px 4px #a57d52;
+    /* border: double 3px ${COLOR_1.dark_brown}; */
     cursor: pointer;
     &:hover {
       background-color: #a57d52;
+      color: whitesmoke;
     }
     &:active {
       box-shadow: 0px 0px 1px 5px #e1e1e1;
     }
   `,
 };
+
 interface OwnerData {
   email: string;
   displayName: string;
@@ -297,6 +303,7 @@ const UserMyPageBox = () => {
       <S.EditButtonBox>
         <Link to='/ownermy/edit/:id'>
           <S.EditButton>내 정보 수정하기</S.EditButton>
+          {cafeInfo ? <DeleteCafe cafeId={cafeInfo?.cafeId} /> : undefined}
         </Link>
       </S.EditButtonBox>
       <S.BottomBox>

--- a/client/src/components/users/UserMyPageBox.tsx
+++ b/client/src/components/users/UserMyPageBox.tsx
@@ -337,7 +337,7 @@ const UserMyPageBox = () => {
     {
       id: 1,
       cafeName: "동대문 카페",
-      image: undefined,
+      image: "",
       address: "서울시 동대문구",
       rating: 1,
       title: "먹자",
@@ -346,7 +346,7 @@ const UserMyPageBox = () => {
     {
       id: 2,
       cafeName: "동대문 카페1",
-      image: undefined,
+      image: "",
       address: "서울시 동대문구",
       rating: 1,
       title: "먹자",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -21,7 +21,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": false,
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
### 🖐🏻 카테고리

---

- [ ] Feature
- [ ] Refactor
- [ ] Fix
- [ ] Test

### 🔥 핵심 구현사항

---

- 카페 메뉴 삭제 구현 / -> 서버 테스트 해봐야함 ( 카페가 등록되었을 때만 삭제 버튼 뜨도록 구현함 )
- 지도에 카페 띄우기 / -> 가상의 카페 데이터로 띄워봄 / 추후 필터링된 카페데이터로 교체하면 됨 


### 구현 화면 
클릭하면 카페 정보가 나오고 카페 이름 /카페 주소 / 카페 페이지로 이동하는 링크가 존재 - > 배포 서버 주소로 이동하게 해놓음 
(현재 인포윈도우로 해서 커스텀이 잘 안되는데 나중에 시간이 남으면 커스텀 오버레이로 바꿔보겠습니다  )
![Jul-22-2023 21-46-19](https://github.com/codestates-seb/seb44_main_034/assets/82064490/ef8eb66a-f1b1-4cf6-a00b-5e7242481553)

